### PR TITLE
feat: otlp metrics

### DIFF
--- a/service-discovery/README.md
+++ b/service-discovery/README.md
@@ -8,6 +8,12 @@ https://opentelemetry.io/docs/
 https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/
 https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#sampler
 
+### proxy conf
+
+if the telemetry instrumentation/appender does not support proxy, configure a system properties (http.proxyHost/http.proxyPort or https.proxyHost/https.proxyPort) proxy by excluding existing http/https internal dependencies (http.nonProxyHosts)
+
+https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html
+
 ## TODO
 Micrometer span_id / trace_id
 Grafana/Prometheus exemplars

--- a/service-discovery/client/Dockerfile
+++ b/service-discovery/client/Dockerfile
@@ -20,8 +20,8 @@ RUN ./mvnw dependency:resolve dependency:go-offline -B
 COPY src ./src
 RUN ./mvnw -o package
 
-FROM hashicorp/consul:1.13.1 as consul
-FROM alpine:3.16
+FROM hashicorp/consul:1.15.2 as consul
+FROM alpine:3.17.3
 
 RUN apk add --no-cache supervisor
 
@@ -35,7 +35,7 @@ RUN adduser --no-create-home -u 1000 -D $APPLICATION_USER
 USER 1000
 WORKDIR /app
 
-ADD --chown=1000:1000 https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.17.0/opentelemetry-javaagent.jar ./opentelemetry-javaagent.jar
+ADD --chown=1000:1000 https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.25.0/opentelemetry-javaagent.jar ./opentelemetry-javaagent.jar
 
 COPY --chown=1000:1000 --from=consul /bin/consul /app/consul
 

--- a/service-discovery/client/pom.xml
+++ b/service-discovery/client/pom.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>2.7.0</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <relativePath/>
+        <!-- lookup parent from repository -->
     </parent>
     <groupId>com.client</groupId>
     <artifactId>client</artifactId>
@@ -16,6 +17,13 @@
     <properties>
         <java.version>17</java.version>
     </properties>
+    <repositories>
+        <repository>
+            <id>spring-milestone</id>
+            <name>Spring Milestone Repository</name>
+            <url>https://repo.spring.io/milestone</url>
+        </repository>
+    </repositories>
     <dependencies>
 
         <dependency>
@@ -26,14 +34,27 @@
 
         <dependency>
             <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>1.11.0-M1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>1.11.0-M1</version>
             <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-otlp</artifactId>
+            <version>1.11.0-M1</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.loki4j</groupId>
             <artifactId>loki-logback-appender</artifactId>
-            <version>1.3.2</version>
+            <version>1.4.0</version>
         </dependency>
 
         <dependency>
@@ -47,7 +68,7 @@
             <artifactId>opentelemetry-extension-annotations</artifactId>
             <version>1.16.0</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-consul-discovery</artifactId>
@@ -76,13 +97,13 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
-			<groupId>org.apache.maven.surefire</groupId>
-			<artifactId>surefire-junit-platform</artifactId>
-			<version>2.22.2</version>
-			<scope>test</scope>
-		</dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit-platform</artifactId>
+            <version>2.22.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/service-discovery/client/src/main/java/com/client/client/ClientApplication.java
+++ b/service-discovery/client/src/main/java/com/client/client/ClientApplication.java
@@ -1,6 +1,7 @@
 package com.client.client;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
@@ -8,6 +9,7 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 @SpringBootApplication
 @EnableFeignClients
 @EnableDiscoveryClient
+@ImportAutoConfiguration(OtlpMetricsExportAutoConfiguration.class)
 public class ClientApplication {
 
 	public static void main(final String[] args) {

--- a/service-discovery/client/src/main/java/com/client/client/OtlpMetricsExportAutoConfiguration.java
+++ b/service-discovery/client/src/main/java/com/client/client/OtlpMetricsExportAutoConfiguration.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.helloworld.service;
+package com.client.client;
 
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.registry.otlp.OtlpConfig;

--- a/service-discovery/client/src/main/java/com/client/client/OtlpProperties.java
+++ b/service-discovery/client/src/main/java/com/client/client/OtlpProperties.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.helloworld.service;
+package com.client.client;
 
 import java.util.Map;
 

--- a/service-discovery/client/src/main/java/com/client/client/OtlpPropertiesConfigAdapter.java
+++ b/service-discovery/client/src/main/java/com/client/client/OtlpPropertiesConfigAdapter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.helloworld.service;
+package com.client.client;
 
 import java.util.Map;
 

--- a/service-discovery/client/src/main/resources/application.yml
+++ b/service-discovery/client/src/main/resources/application.yml
@@ -7,15 +7,24 @@ server:
       enabled: true
 spring:
   cloud:
-    # https://cloud.spring.io/spring-cloud-consul/reference/html/appendix.html
     consul:
       host: localhost
       discovery:
-        prefer-ip-address: false
-        # return only healthy services
         query-passing: true
+        prefer-ip-address: false
         tags: prometheus
 management:
+
+  otlp:
+    metrics:
+      export:
+        enabled: true
+        step: 10s
+        url: http://mimir:9009/otlp/v1/metrics
+        # url: https://prometheus-prod-24-prod-eu-west-2.grafana.net/otlp/v1/metrics
+        # headers:
+        #   Authorization: Basic ####
+
   metrics:
     distribution:
       slo:
@@ -29,7 +38,8 @@ management:
       percentiles:
         http:
           server:
-            requests: 0.1, 0.2, 0.1, 0.5, 0.9, 0.95, 0.99, 0.999
+            requests: 0.1, 0.2, 0.5, 0.9, 0.95, 0.99, 0.999
+      
   endpoints:
     web:
       exposure:

--- a/service-discovery/client/src/main/resources/logback.xml
+++ b/service-discovery/client/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
         </http>
         <format>
             <label>
-                <pattern>application=${app},host=${HOSTNAME},level=%level</pattern>
+                <pattern>application=${app},host=${HOSTNAME},level=%level,env=${SERVICE_ENV}</pattern>
             </label>
             <message>
                 <pattern>l=%level h=${HOSTNAME} c=%logger{20} t=%thread traceId=%X{trace_id} spanId=%X{span_id} | %msg %ex</pattern>

--- a/service-discovery/client/supervisor.d/app.ini
+++ b/service-discovery/client/supervisor.d/app.ini
@@ -5,7 +5,7 @@ command=java
     -Dotel.service.name=%(ENV_SERVICE_NAME)s
     -Dotel.traces.sampler=parentbased_traceidratio
     -Dotel.traces.sampler.arg=0.1
-    -jar /app/main.jar --spring.application.name=%(ENV_SERVICE_NAME)s
+    -jar /app/main.jar --spring.application.name=%(ENV_SERVICE_NAME)s --management.otlp.metrics.export.resourceAttributes.service.name=%(ENV_SERVICE_NAME)s --management.otlp.metrics.export.resourceAttributes.service.instance.id=%(host_node_name)s --management.metrics.tags.env=%(ENV_SERVICE_ENV)s --management.metrics.tags.application=%(ENV_SERVICE_NAME)s
 autorestart=false
 startretries=0
 stdout_logfile=/dev/fd/1

--- a/service-discovery/compose.yml
+++ b/service-discovery/compose.yml
@@ -22,6 +22,7 @@ services:
     environment:
       - CONSUL_ARGS=-retry-join consul-server
       - SERVICE_NAME=users-service
+      - SERVICE_ENV=dev
       - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317
       - OTEL_METRICS_EXPORTER=none

--- a/service-discovery/compose.yml
+++ b/service-discovery/compose.yml
@@ -2,7 +2,7 @@
 version: '3.8'
 services:
   consul-server:
-    image: hashicorp/consul:1.13.1
+    image: hashicorp/consul:1.15.2
     restart: always
     volumes:
      - ./consul.d/server/server.json:/consul/config/server.json:ro
@@ -39,6 +39,7 @@ services:
     environment:
       - CONSUL_ARGS=-retry-join consul-server
       - SERVICE_NAME=client
+      - SERVICE_ENV=dev
       - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317
       - OTEL_METRICS_EXPORTER=none
@@ -74,12 +75,23 @@ services:
       - consul-server
 
   loki:
-    image: grafana/loki:2.6.1
+    image: grafana/loki:2.7.5
+    command: -config.file=/etc/loki/local-config.yaml -query-scheduler.max-outstanding-requests-per-tenant=2048 -querier.max-outstanding-requests-per-tenant=2048
+    volumes:
+      - ./loki/:/etc/loki/:ro
+    networks:
+      - bridge
+
+  mimir:
+    image: grafana/mimir:2.7.1
+    volumes:
+      - ./mimir/mimir.yaml:/etc/mimir.yaml
+    command: --config.file=/etc/mimir.yaml
     networks:
       - bridge
 
   tempo:
-    image: grafana/tempo:1.5.0
+    image: grafana/tempo:2.0.1
     volumes:
       - ./tempo/tempo-local.yaml:/etc/tempo.yaml:ro
     command: [ "-config.file=/etc/tempo.yaml" ]
@@ -87,7 +99,10 @@ services:
       - bridge
 
   grafana:
-    image: grafana/grafana-oss:9.1.1
+    image: grafana/grafana-oss:9.4.7
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
     ports:
       - 3000:3000
     networks:

--- a/service-discovery/grafana/provisioning/dashboards/JVM (Micrometer) - Mimir.json
+++ b/service-discovery/grafana/provisioning/dashboards/JVM (Micrometer) - Mimir.json
@@ -43,6 +43,7 @@
   "fiscalYearStartMonth": 0,
   "gnetId": 4701,
   "graphTooltip": 1,
+  "id": 5,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -107,7 +108,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -141,11 +142,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "process_uptime_seconds{application=\"$application\", instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "process_uptime{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 14400
         }
@@ -221,11 +224,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "process_start_time_seconds{application=\"$application\", instance=\"$instance\"}*1000",
+          "editorMode": "code",
+          "expr": "process_start_time{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 14400
         }
@@ -306,10 +311,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", instance=\"$instance\", area=\"heap\"})*100/sum(jvm_memory_max_bytes{application=\"$application\",instance=\"$instance\", area=\"heap\"})",
+          "editorMode": "code",
+          "expr": "sum(jvm_memory_used{application=\"$application\", instance=\"$instance\", area=\"heap\"})*100/sum(jvm_memory_max{application=\"$application\",instance=\"$instance\", area=\"heap\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
+          "range": true,
           "refId": "A",
           "step": 14400
         }
@@ -400,10 +407,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", instance=\"$instance\", area=\"nonheap\"})*100/sum(jvm_memory_max_bytes{application=\"$application\",instance=\"$instance\", area=\"nonheap\"})",
+          "editorMode": "code",
+          "expr": "sum(jvm_memory_used{application=\"$application\", instance=\"$instance\", area=\"nonheap\"})*100/sum(jvm_memory_max{application=\"$application\",instance=\"$instance\", area=\"nonheap\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
+          "range": true,
           "refId": "A",
           "step": 14400
         }
@@ -525,10 +534,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(http_server_requests_seconds_count{application=\"$application\", instance=\"$instance\"}[1m]))",
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_requests_count{application=\"$application\", instance=\"$instance\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "HTTP",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -654,10 +665,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(http_server_requests_seconds_count{application=\"$application\", instance=\"$instance\", status=~\"5..\"}[1m]))",
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_requests_count{application=\"$application\", instance=\"$instance\", status=~\"5..\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "HTTP - 5xx",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -719,7 +732,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -752,11 +765,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(http_server_requests_seconds_sum{application=\"$application\", instance=\"$instance\", status!~\"5..\"}[1m]))/sum(rate(http_server_requests_seconds_count{application=\"$application\", instance=\"$instance\", status!~\"5..\"}[1m]))",
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_requests_sum{application=\"$application\", instance=\"$instance\", status!~\"5..\"}[1m]))/sum(rate(http_server_requests_count{application=\"$application\", instance=\"$instance\", status!~\"5..\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
           "legendFormat": "HTTP - AVG",
+          "range": true,
           "refId": "A"
         },
         {
@@ -764,11 +779,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "max(http_server_requests_seconds_max{application=\"$application\", instance=\"$instance\", status!~\"5..\"})",
+          "editorMode": "code",
+          "expr": "max(http_server_requests{application=\"$application\", instance=\"$instance\", status!~\"5..\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
           "legendFormat": "HTTP - MAX",
+          "range": true,
           "refId": "B"
         }
       ],
@@ -864,11 +881,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "tomcat_threads_busy_threads{application=\"$application\", instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "tomcat_threads_busy{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
           "legendFormat": "TOMCAT - BSY",
+          "range": true,
           "refId": "A"
         },
         {
@@ -876,11 +895,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "tomcat_threads_current_threads{application=\"$application\", instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "tomcat_threads_current{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
           "legendFormat": "TOMCAT - CUR",
+          "range": true,
           "refId": "B"
         },
         {
@@ -888,11 +909,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "tomcat_threads_config_max_threads{application=\"$application\", instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "tomcat_threads_config_max{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
           "legendFormat": "TOMCAT - MAX",
+          "range": true,
           "refId": "C"
         },
         {
@@ -900,11 +923,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
+          "editorMode": "code",
           "expr": "jetty_threads_busy{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
           "legendFormat": "JETTY - BSY",
+          "range": true,
           "refId": "D"
         },
         {
@@ -924,11 +949,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
+          "editorMode": "code",
           "expr": "jetty_threads_config_max{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
           "legendFormat": "JETTY - MAX",
+          "range": true,
           "refId": "F"
         }
       ],
@@ -1050,11 +1077,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", instance=\"$instance\", area=\"heap\"})",
+          "editorMode": "code",
+          "expr": "sum(jvm_memory_used{application=\"$application\", instance=\"$instance\", area=\"heap\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "used",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 2400
         },
@@ -1063,10 +1092,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\", instance=\"$instance\", area=\"heap\"})",
+          "editorMode": "code",
+          "expr": "sum(jvm_memory_committed{application=\"$application\", instance=\"$instance\", area=\"heap\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "committed",
+          "range": true,
           "refId": "B",
           "step": 2400
         },
@@ -1075,10 +1106,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(jvm_memory_max_bytes{application=\"$application\", instance=\"$instance\", area=\"heap\"})",
+          "editorMode": "code",
+          "expr": "sum(jvm_memory_max{application=\"$application\", instance=\"$instance\", area=\"heap\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "max",
+          "range": true,
           "refId": "C",
           "step": 2400
         }
@@ -1175,12 +1208,14 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", instance=\"$instance\", area=\"nonheap\"})",
+          "editorMode": "code",
+          "expr": "sum(jvm_memory_used{application=\"$application\", instance=\"$instance\", area=\"nonheap\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "used",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 2400
         },
@@ -1189,10 +1224,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\", instance=\"$instance\", area=\"nonheap\"})",
+          "editorMode": "code",
+          "expr": "sum(jvm_memory_committed{application=\"$application\", instance=\"$instance\", area=\"nonheap\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "committed",
+          "range": true,
           "refId": "B",
           "step": 2400
         },
@@ -1201,10 +1238,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(jvm_memory_max_bytes{application=\"$application\", instance=\"$instance\", area=\"nonheap\"})",
+          "editorMode": "code",
+          "expr": "sum(jvm_memory_max{application=\"$application\", instance=\"$instance\", area=\"nonheap\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "max",
+          "range": true,
           "refId": "C",
           "step": 2400
         }
@@ -1301,11 +1340,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", instance=\"$instance\"})",
+          "editorMode": "code",
+          "expr": "sum(jvm_memory_used{application=\"$application\", instance=\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "used",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 2400
         },
@@ -1314,10 +1355,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\", instance=\"$instance\"})",
+          "editorMode": "code",
+          "expr": "sum(jvm_memory_committed{application=\"$application\", instance=\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "committed",
+          "range": true,
           "refId": "B",
           "step": 2400
         },
@@ -1326,10 +1369,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(jvm_memory_max_bytes{application=\"$application\", instance=\"$instance\"})",
+          "editorMode": "code",
+          "expr": "sum(jvm_memory_max{application=\"$application\", instance=\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "max",
+          "range": true,
           "refId": "C",
           "step": 2400
         }
@@ -1426,12 +1471,14 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "process_memory_vss_bytes{application=\"$application\", instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "process_memory_vss{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 2,
           "legendFormat": "vss",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 2400
         },
@@ -1440,10 +1487,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "process_memory_rss_bytes{application=\"$application\", instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "process_memory_rss{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "rss",
+          "range": true,
           "refId": "B"
         },
         {
@@ -1451,10 +1500,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "process_memory_swap_bytes{application=\"$application\", instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "process_memory_swap{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "swap",
+          "range": true,
           "refId": "C"
         },
         {
@@ -1462,10 +1513,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "process_memory_rss_bytes{application=\"$application\", instance=\"$instance\"} + process_memory_swap_bytes{application=\"$application\", instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "process_memory_rss{application=\"$application\", instance=\"$instance\"} + process_memory_swap{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "total",
+          "range": true,
           "refId": "D"
         }
       ],
@@ -1546,7 +1599,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1672,7 +1726,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1784,7 +1839,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1826,11 +1882,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "jvm_threads_live_threads{application=\"$application\", instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "jvm_threads_live{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "live",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 2400
         },
@@ -1839,11 +1897,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "jvm_threads_daemon_threads{application=\"$application\", instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "jvm_threads_daemon{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "daemon",
           "metric": "",
+          "range": true,
           "refId": "B",
           "step": 2400
         },
@@ -1852,10 +1912,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "jvm_threads_peak_threads{application=\"$application\", instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "jvm_threads_peak{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "peak",
+          "range": true,
           "refId": "C",
           "step": 2400
         },
@@ -1864,11 +1926,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "process_threads{application=\"$application\", instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "process{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "process",
+          "range": true,
           "refId": "D",
           "step": 2400
         }
@@ -1921,7 +1985,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2054,10 +2119,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "jvm_threads_states_threads{application=\"$application\", instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "jvm_threads_states{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{state}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -2111,7 +2178,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2229,12 +2297,14 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "increase(logback_events_total{application=\"$application\", instance=\"$instance\"}[1m])",
+          "editorMode": "code",
+          "expr": "increase(logback_events{application=\"$application\", instance=\"$instance\"}[1m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{level}}",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 1200
         }
@@ -2290,7 +2360,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2332,12 +2403,14 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "process_files_open_files{application=\"$application\", instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "process_files_open{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
           "legendFormat": "open",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 2400
         },
@@ -2346,12 +2419,14 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "process_files_max_files{application=\"$application\", instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "process_files_max{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
           "legendFormat": "max",
           "metric": "",
+          "range": true,
           "refId": "B",
           "step": 2400
         }
@@ -2432,7 +2507,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2475,13 +2551,15 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "jvm_memory_used_bytes{application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_heap\"}",
+          "editorMode": "code",
+          "expr": "jvm_memory_used{application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_heap\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "used",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 1800
         },
@@ -2490,13 +2568,15 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "jvm_memory_committed_bytes{application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_heap\"}",
+          "editorMode": "code",
+          "expr": "jvm_memory_committed{application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_heap\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "commited",
           "metric": "",
+          "range": true,
           "refId": "B",
           "step": 1800
         },
@@ -2505,13 +2585,15 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "jvm_memory_max_bytes{application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_heap\"}",
+          "editorMode": "code",
+          "expr": "jvm_memory_max{application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_heap\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "max",
           "metric": "",
+          "range": true,
           "refId": "C",
           "step": 1800
         }
@@ -2591,7 +2673,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2634,13 +2717,15 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "jvm_memory_used_bytes{application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_nonheap\"}",
+          "editorMode": "code",
+          "expr": "jvm_memory_used{application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_nonheap\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "used",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 1800
         },
@@ -2649,13 +2734,15 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "jvm_memory_committed_bytes{application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_nonheap\"}",
+          "editorMode": "code",
+          "expr": "jvm_memory_committed{application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_nonheap\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "commited",
           "metric": "",
+          "range": true,
           "refId": "B",
           "step": 1800
         },
@@ -2664,13 +2751,15 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "jvm_memory_max_bytes{application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_nonheap\"}",
+          "editorMode": "code",
+          "expr": "jvm_memory_max{application=\"$application\", instance=\"$instance\", id=~\"$jvm_memory_pool_nonheap\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "max",
           "metric": "",
+          "range": true,
           "refId": "C",
           "step": 1800
         }
@@ -2750,7 +2839,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2789,11 +2879,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(jvm_gc_pause_seconds_count{application=\"$application\", instance=\"$instance\"}[1m])",
+          "editorMode": "code",
+          "expr": "rate(jvm_gc_pause_count{application=\"$application\", instance=\"$instance\"}[1m])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
           "legendFormat": "{{action}} ({{cause}})",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -2846,7 +2938,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2854,7 +2947,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -2885,7 +2978,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(jvm_gc_pause_seconds_sum{application=\"$application\", instance=\"$instance\"}[1m])/rate(jvm_gc_pause_seconds_count{application=\"$application\", instance=\"$instance\"}[1m])",
+          "editorMode": "code",
+          "expr": "rate(jvm_gc_pause_sum{application=\"$application\", instance=\"$instance\"}[1m])/rate(jvm_gc_pause_count{application=\"$application\", instance=\"$instance\"}[1m])",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2956,7 +3050,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2995,11 +3090,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(jvm_gc_memory_allocated_bytes_total{application=\"$application\", instance=\"$instance\"}[1m])",
+          "editorMode": "code",
+          "expr": "rate(jvm_gc_memory_allocated{application=\"$application\", instance=\"$instance\"}[1m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "allocated",
+          "range": true,
           "refId": "A"
         },
         {
@@ -3007,11 +3104,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(jvm_gc_memory_promoted_bytes_total{application=\"$application\", instance=\"$instance\"}[1m])",
+          "editorMode": "code",
+          "expr": "rate(jvm_gc_memory_promoted{application=\"$application\", instance=\"$instance\"}[1m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "promoted",
+          "range": true,
           "refId": "B"
         }
       ],
@@ -3090,7 +3189,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3129,11 +3229,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "jvm_classes_loaded_classes{application=\"$application\", instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "jvm_classes_loaded{application=\"$application\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "loaded",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 1200
         }
@@ -3186,7 +3288,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3225,13 +3328,15 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "delta(jvm_classes_loaded_classes{application=\"$application\",instance=\"$instance\"}[1m])",
+          "editorMode": "code",
+          "expr": "delta(jvm_classes_loaded{application=\"$application\",instance=\"$instance\"}[1m])",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "delta-1m",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 1200
         }
@@ -3311,7 +3416,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3350,11 +3456,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "jvm_buffer_memory_used_bytes{application=\"$application\", instance=\"$instance\", id=\"direct\"}",
+          "editorMode": "code",
+          "expr": "jvm_buffer_memory_used{application=\"$application\", instance=\"$instance\", id=\"direct\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "used",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 2400
         },
@@ -3363,11 +3471,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "jvm_buffer_total_capacity_bytes{application=\"$application\", instance=\"$instance\", id=\"direct\"}",
+          "editorMode": "code",
+          "expr": "jvm_buffer_total_capacity{application=\"$application\", instance=\"$instance\", id=\"direct\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "capacity",
           "metric": "",
+          "range": true,
           "refId": "B",
           "step": 2400
         }
@@ -3422,7 +3532,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3461,11 +3572,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "jvm_buffer_count_buffers{application=\"$application\", instance=\"$instance\", id=\"direct\"}",
+          "editorMode": "code",
+          "expr": "jvm_buffer_count{application=\"$application\", instance=\"$instance\", id=\"direct\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "count",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 2400
         }
@@ -3519,7 +3632,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3558,11 +3672,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "jvm_buffer_memory_used_bytes{application=\"$application\", instance=\"$instance\", id=\"mapped\"}",
+          "editorMode": "code",
+          "expr": "jvm_buffer_memory_used{application=\"$application\", instance=\"$instance\", id=\"mapped\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "used",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 2400
         },
@@ -3630,7 +3746,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3669,11 +3786,13 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "jvm_buffer_count_buffers{application=\"$application\", instance=\"$instance\", id=\"mapped\"}",
+          "editorMode": "code",
+          "expr": "jvm_buffer_count{application=\"$application\", instance=\"$instance\", id=\"mapped\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "count",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 2400
         }
@@ -3691,9 +3810,9 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "Prometheus",
-          "value": "Prometheus"
+          "selected": true,
+          "text": "Mimir",
+          "value": "Mimir"
         },
         "hide": 2,
         "includeAll": false,
@@ -3742,14 +3861,14 @@
         "allFormat": "glob",
         "current": {
           "selected": false,
-          "text": "63218b186047:8080",
-          "value": "63218b186047:8080"
+          "text": "63218b186047",
+          "value": "63218b186047"
         },
         "datasource": {
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "",
+        "definition": "label_values(jvm_memory_used{application=\"$application\"}, instance)",
         "hide": 0,
         "includeAll": false,
         "label": "Instance",
@@ -3758,8 +3877,8 @@
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(jvm_memory_used_bytes{application=\"$application\"}, instance)",
-          "refId": "Prometheus-instance-Variable-Query"
+          "query": "label_values(jvm_memory_used{application=\"$application\"}, instance)",
+          "refId": "StandardVariableQuery"
         },
         "refresh": 2,
         "regex": "",
@@ -3781,7 +3900,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "",
+        "definition": "label_values(jvm_memory_used{application=\"$application\", instance=\"$instance\", area=\"heap\"},id)",
         "hide": 0,
         "includeAll": true,
         "label": "JVM Memory Pools Heap",
@@ -3790,8 +3909,8 @@
         "name": "jvm_memory_pool_heap",
         "options": [],
         "query": {
-          "query": "label_values(jvm_memory_used_bytes{application=\"$application\", instance=\"$instance\", area=\"heap\"},id)",
-          "refId": "Prometheus-jvm_memory_pool_heap-Variable-Query"
+          "query": "label_values(jvm_memory_used{application=\"$application\", instance=\"$instance\", area=\"heap\"},id)",
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -3813,7 +3932,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "",
+        "definition": "label_values(jvm_memory_used{application=\"$application\", instance=\"$instance\", area=\"nonheap\"},id)",
         "hide": 0,
         "includeAll": true,
         "label": "JVM Memory Pools Non-Heap",
@@ -3822,8 +3941,8 @@
         "name": "jvm_memory_pool_nonheap",
         "options": [],
         "query": {
-          "query": "label_values(jvm_memory_used_bytes{application=\"$application\", instance=\"$instance\", area=\"nonheap\"},id)",
-          "refId": "Prometheus-jvm_memory_pool_nonheap-Variable-Query"
+          "query": "label_values(jvm_memory_used{application=\"$application\", instance=\"$instance\", area=\"nonheap\"},id)",
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -3867,8 +3986,8 @@
     ]
   },
   "timezone": "browser",
-  "title": "JVM (Micrometer)",
-  "uid": "2QBAjbg4k",
+  "title": "JVM (Micrometer) - Mimir",
+  "uid": "dN7v-xPVz",
   "version": 4,
   "weekStart": ""
 }

--- a/service-discovery/grafana/provisioning/dashboards/Micrometer Spring Throughput - Mimir.json
+++ b/service-discovery/grafana/provisioning/dashboards/Micrometer Spring Throughput - Mimir.json
@@ -191,7 +191,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "up{application=\"${application}\", host=\"${host}\"}",
+          "expr": "clamp_max(process_uptime{application=\"${application}\", instance=\"${host}\"}, 1)",
           "format": "time_series",
           "intervalFactor": 1,
           "range": true,
@@ -202,12 +202,29 @@
       "type": "stat"
     },
     {
-      "columns": [],
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "fontSize": "100%",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
         "w": 22,
@@ -217,52 +234,40 @@
       "hideTimeOverride": false,
       "id": 26,
       "links": [],
-      "scroll": true,
-      "showHeader": true,
-      "sort": {
-        "col": 0,
-        "desc": true
-      },
-      "styles": [
-        {
-          "alias": "Time",
-          "align": "auto",
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "pattern": "Time",
-          "type": "date"
-        },
-        {
-          "alias": "",
-          "align": "auto",
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
+      "options": {
+        "displayMode": "lcd",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
           ],
-          "decimals": 2,
-          "pattern": "/.*/",
-          "thresholds": [],
-          "type": "number",
-          "unit": "short"
-        }
-      ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "http_server_requests_seconds_bucket{application=\"$application\", host=\"$host\", le=\"0.05\"}",
-          "format": "table",
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(http_server_requests{application=\"$application\", instance=\"$host\"}) by (quantile)",
+          "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
-          "legendFormat": "",
+          "legendFormat": "__auto",
+          "range": false,
           "refId": "A"
         }
       ],
-      "title": "Number Requests that missed 50ms SLA",
-      "transform": "table",
-      "type": "table-old"
+      "title": "Response time",
+      "type": "bargauge"
     },
     {
       "datasource": {
@@ -299,7 +304,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -334,7 +339,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "process_uptime_seconds{application=\"$application\", host=\"$host\"}",
+          "expr": "process_uptime{application=\"$application\", instance=\"$host\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "range": true,
@@ -430,7 +435,7 @@
       },
       "gridPos": {
         "h": 9,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 17
       },
@@ -458,10 +463,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(http_server_requests_seconds_count{application=\"$application\", host=\"$host\"}[1m])",
+          "editorMode": "code",
+          "expr": "rate(http_server_requests_count{application=\"$application\", instance=\"$host\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{method}}-{{status}}-{{uri}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -528,8 +535,8 @@
       },
       "gridPos": {
         "h": 9,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 8,
         "y": 17
       },
       "id": 12,
@@ -553,7 +560,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "rate(http_server_requests_seconds_sum{application=\"$application\", host=\"$host\"}[1m])/rate(http_server_requests_seconds_count{application=\"$application\", host=\"$host\"}[1m])",
+          "editorMode": "code",
+          "expr": "rate(http_server_requests_sum{application=\"$application\", instance=\"$host\"}[1m])/rate(http_server_requests_count{application=\"$application\", instance=\"$host\"}[1m])",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -562,136 +570,6 @@
         }
       ],
       "title": "Mean response time",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 26
-      },
-      "id": 14,
-      "links": [],
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "9.4.7",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{application=\"$application\", host=\"$host\"}[1m])) by (le))",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "95%",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "histogram_quantile(0.9, sum(rate(http_server_requests_seconds_bucket{application=\"$application\", host=\"$host\"}[1m])) by (le))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "90%",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "histogram_quantile(0.75, sum(rate(http_server_requests_seconds_bucket{application=\"$application\", host=\"$host\"}[1m])) by (le))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "75%",
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "histogram_quantile(0.5, sum(rate(http_server_requests_seconds_bucket{application=\"$application\", host=\"$host\"}[1m])) by (le))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "50%",
-          "refId": "D"
-        }
-      ],
-      "title": "Response time of 50%, 75%, 90%, 95% of requests",
       "type": "timeseries"
     },
     {
@@ -739,7 +617,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -753,9 +632,9 @@
       },
       "gridPos": {
         "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 26
+        "w": 8,
+        "x": 16,
+        "y": 17
       },
       "id": 16,
       "links": [],
@@ -778,10 +657,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by(uri, method) (rate(http_server_requests_seconds_count{application=\"$application\"}[1m])))",
+          "editorMode": "code",
+          "expr": "topk(10, sum by(uri, method) (rate(http_server_requests_count{application=\"$application\", instance=\"$host\"}[1m])))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -798,9 +679,9 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "Prometheus",
-          "value": "Prometheus"
+          "selected": true,
+          "text": "Mimir",
+          "value": "Mimir"
         },
         "hide": 2,
         "includeAll": false,
@@ -848,14 +729,14 @@
       {
         "current": {
           "selected": false,
-          "text": "63218b186047",
-          "value": "63218b186047"
+          "text": "7bfd6e12f084",
+          "value": "7bfd6e12f084"
         },
         "datasource": {
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(up{application=\"$application\"}, host)",
+        "definition": "label_values(process_uptime{application=\"$application\"}, instance)",
         "hide": 0,
         "includeAll": false,
         "label": "host",
@@ -863,7 +744,7 @@
         "name": "host",
         "options": [],
         "query": {
-          "query": "label_values(up{application=\"$application\"}, host)",
+          "query": "label_values(process_uptime{application=\"$application\"}, instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -927,8 +808,8 @@
     ]
   },
   "timezone": "",
-  "title": "Micrometer Spring Throughput",
-  "uid": "twqdYjziz",
-  "version": 1,
+  "title": "Micrometer Spring Throughput - Mimir",
+  "uid": "MkcEBbPVk",
+  "version": 2,
   "weekStart": ""
 }

--- a/service-discovery/grafana/provisioning/datasources/mimir.yml
+++ b/service-discovery/grafana/provisioning/datasources/mimir.yml
@@ -1,12 +1,12 @@
 apiVersion: 1
 
 datasources:
-- name: Prometheus
+- name: Mimir
   type: prometheus
-  uid: prometheus
+  uid: mimir
   access: proxy
   orgId: 1
-  url: http://prometheus:9090
+  url: http://mimir:9009/prometheus
   basicAuth: false
-  isDefault: false
+  isDefault: true
   editable: false

--- a/service-discovery/loki/local-config.yaml
+++ b/service-discovery/loki/local-config.yaml
@@ -1,0 +1,42 @@
+# https://github.com/grafana/loki/blob/main/cmd/loki/loki-local-config.yaml
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+# By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
+# analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
+#
+# Statistics help us better understand how Loki is used, and they show us performance
+# levels for most users. This helps us prioritize features and documentation.
+# For more information on what's sent, look at
+# https://github.com/grafana/loki/blob/main/pkg/usagestats/stats.go
+# Refer to the buildReport method to see what goes into a report.
+#
+# If you would like to disable reporting, uncomment the following lines:
+analytics:
+ reporting_enabled: false

--- a/service-discovery/mimir/mimir.yaml
+++ b/service-discovery/mimir/mimir.yaml
@@ -1,0 +1,47 @@
+# https://grafana.com/docs/mimir/latest/operators-guide/get-started/#start-grafana-mimir
+# Do not use this configuration in production.
+# It is for demonstration purposes only.
+multitenancy_enabled: false
+usage_stats:
+  enabled: false
+
+blocks_storage:
+  backend: filesystem
+  bucket_store:
+    sync_dir: /tmp/mimir/tsdb-sync
+  filesystem:
+    dir: /tmp/mimir/data/tsdb
+  tsdb:
+    dir: /tmp/mimir/tsdb
+
+compactor:
+  data_dir: /tmp/mimir/compactor
+  sharding_ring:
+    kvstore:
+      store: memberlist
+
+distributor:
+  ring:
+    instance_addr: 0.0.0.0
+    kvstore:
+      store: memberlist
+
+ingester:
+  ring:
+    instance_addr: 0.0.0.0
+    kvstore:
+      store: memberlist
+    replication_factor: 1
+
+ruler_storage:
+  backend: filesystem
+  filesystem:
+    dir: /tmp/mimir/rules
+
+server:
+  http_listen_port: 9009
+  log_level: debug
+
+store_gateway:
+  sharding_ring:
+    replication_factor: 1

--- a/service-discovery/prometheus/Dockerfile
+++ b/service-discovery/prometheus/Dockerfile
@@ -1,5 +1,5 @@
-FROM hashicorp/consul:1.13.1 as consul
-FROM prom/prometheus:v2.38.0
+FROM hashicorp/consul:1.15.2 as consul
+FROM prom/prometheus:v2.43.0
 
 COPY --from=consul /bin/consul /bin/consul
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh

--- a/service-discovery/service/Dockerfile
+++ b/service-discovery/service/Dockerfile
@@ -20,8 +20,8 @@ RUN ./mvnw dependency:resolve dependency:go-offline -B
 COPY src ./src
 RUN ./mvnw -o package
 
-FROM hashicorp/consul:1.13.1 as consul
-FROM alpine:3.16
+FROM hashicorp/consul:1.15.2 as consul
+FROM alpine:3.17.3
 
 RUN apk add --no-cache supervisor
 
@@ -35,7 +35,7 @@ RUN adduser --no-create-home -u 1000 -D $APPLICATION_USER
 USER 1000
 WORKDIR /app
 
-ADD --chown=1000:1000 https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.17.0/opentelemetry-javaagent.jar ./opentelemetry-javaagent.jar
+ADD --chown=1000:1000 https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.25.0/opentelemetry-javaagent.jar ./opentelemetry-javaagent.jar
 
 COPY --chown=1000:1000 --from=consul /bin/consul /app/consul
 

--- a/service-discovery/service/README.md
+++ b/service-discovery/service/README.md
@@ -6,6 +6,12 @@
 - vscode plugin: Spring Initializr Java Support
 - ctrl+shift+p: Spring Initializr create project
 
+### debug 
+install jar sources : 
+```
+mvn dependency:sources
+```
+
 ### Dockerfile
 https://snyk.io/blog/best-practices-to-build-java-containers-with-docker/
 

--- a/service-discovery/service/pom.xml
+++ b/service-discovery/service/pom.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>2.7.0</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <relativePath/>
+        <!-- lookup parent from repository -->
     </parent>
     <groupId>com.helloworld</groupId>
     <artifactId>service</artifactId>
@@ -16,6 +17,13 @@
     <properties>
         <java.version>17</java.version>
     </properties>
+    <repositories>
+        <repository>
+            <id>spring-milestone</id>
+            <name>Spring Milestone Repository</name>
+            <url>https://repo.spring.io/milestone</url>
+        </repository>
+    </repositories>
     <dependencies>
 
         <dependency>
@@ -26,14 +34,27 @@
 
         <dependency>
             <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>1.11.0-M1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>1.11.0-M1</version>
             <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-otlp</artifactId>
+            <version>1.11.0-M1</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.loki4j</groupId>
             <artifactId>loki-logback-appender</artifactId>
-            <version>1.3.2</version>
+            <version>1.4.0</version>
         </dependency>
 
         <dependency>
@@ -72,11 +93,11 @@
         </dependency>
 
         <dependency>
-			<groupId>org.apache.maven.surefire</groupId>
-			<artifactId>surefire-junit-platform</artifactId>
-			<version>2.22.2</version>
-			<scope>test</scope>
-		</dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit-platform</artifactId>
+            <version>2.22.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/service-discovery/service/src/main/java/com/helloworld/service/OtlpMetricsExportAutoConfiguration.java
+++ b/service-discovery/service/src/main/java/com/helloworld/service/OtlpMetricsExportAutoConfiguration.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package com.helloworld.service;
+ 
+ import io.micrometer.core.instrument.Clock;
+import io.micrometer.registry.otlp.OtlpConfig;
+import io.micrometer.registry.otlp.OtlpMeterRegistry;
+ 
+ import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
+ import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+ import org.springframework.boot.actuate.autoconfigure.metrics.export.ConditionalOnEnabledMetricsExport;
+ import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
+ import org.springframework.boot.autoconfigure.AutoConfiguration;
+ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+ import org.springframework.boot.context.properties.EnableConfigurationProperties;
+ import org.springframework.context.annotation.Bean;
+ 
+ /**
+  * {@link EnableAutoConfiguration Auto-configuration} for exporting metrics to OTLP.
+  *
+  * @author Eddú Meléndez
+  * @since 3.0.0
+  */
+ @AutoConfiguration(
+         before = { CompositeMeterRegistryAutoConfiguration.class, SimpleMetricsExportAutoConfiguration.class },
+         after = MetricsAutoConfiguration.class)
+ @ConditionalOnBean(Clock.class)
+ @ConditionalOnClass(OtlpMeterRegistry.class)
+ @ConditionalOnEnabledMetricsExport("otlp")
+ @EnableConfigurationProperties(OtlpProperties.class)
+ public class OtlpMetricsExportAutoConfiguration {
+ 
+     private final OtlpProperties properties;
+ 
+     public OtlpMetricsExportAutoConfiguration(OtlpProperties properties) {
+         this.properties = properties;
+     }
+ 
+     @Bean
+     @ConditionalOnMissingBean
+     public OtlpConfig otlpConfig() {
+         return new OtlpPropertiesConfigAdapter(this.properties);
+     }
+ 
+     @Bean
+     @ConditionalOnMissingBean
+     public OtlpMeterRegistry otlpMeterRegistry(OtlpConfig otlpConfig, Clock clock) {
+         return new OtlpMeterRegistry(otlpConfig, clock);
+     }
+ 
+ }

--- a/service-discovery/service/src/main/java/com/helloworld/service/OtlpProperties.java
+++ b/service-discovery/service/src/main/java/com/helloworld/service/OtlpProperties.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package com.helloworld.service;
+ 
+ import java.util.Map;
+ 
+ import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.StepRegistryProperties;
+ import org.springframework.boot.context.properties.ConfigurationProperties;
+ 
+ /**
+  * {@link ConfigurationProperties @ConfigurationProperties} for configuring OTLP metrics
+  * export.
+  *
+  * @author Eddú Meléndez
+  * @since 3.0.0
+  */
+ @ConfigurationProperties(prefix = "management.otlp.metrics.export")
+ public class OtlpProperties extends StepRegistryProperties {
+ 
+     /**
+      * URI of the OLTP server.
+      */
+     private String url = "http://localhost:4318/v1/metrics";
+ 
+     /**
+      * Monitored resource's attributes.
+      */
+     private Map<String, String> resourceAttributes;
+ 
+     /**
+      * Headers for the exported metrics.
+      */
+     private Map<String, String> headers;
+ 
+     public String getUrl() {
+         return this.url;
+     }
+ 
+     public void setUrl(String url) {
+         this.url = url;
+     }
+ 
+     public Map<String, String> getResourceAttributes() {
+         return this.resourceAttributes;
+     }
+ 
+     public void setResourceAttributes(Map<String, String> resourceAttributes) {
+         this.resourceAttributes = resourceAttributes;
+     }
+ 
+     public Map<String, String> getHeaders() {
+         return this.headers;
+     }
+ 
+     public void setHeaders(Map<String, String> headers) {
+         this.headers = headers;
+     }
+ 
+ }

--- a/service-discovery/service/src/main/java/com/helloworld/service/OtlpPropertiesConfigAdapter.java
+++ b/service-discovery/service/src/main/java/com/helloworld/service/OtlpPropertiesConfigAdapter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package com.helloworld.service;
+
+ import java.util.Map;
+ 
+ import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.StepRegistryPropertiesConfigAdapter;
+
+import io.micrometer.registry.otlp.OtlpConfig;
+ 
+ /**
+  * Adapter to convert {@link OtlpProperties} to an {@link OtlpConfig}.
+  *
+  * @author Eddú Meléndez
+  */
+ class OtlpPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<OtlpProperties> implements OtlpConfig {
+ 
+     OtlpPropertiesConfigAdapter(OtlpProperties properties) {
+         super(properties);
+     }
+ 
+     @Override
+     public String prefix() {
+         return "management.otlp.metrics.export";
+     }
+ 
+     @Override
+     public String url() {
+         return get(OtlpProperties::getUrl, OtlpConfig.super::url);
+     }
+ 
+     @Override
+     public Map<String, String> resourceAttributes() {
+         return get(OtlpProperties::getResourceAttributes, OtlpConfig.super::resourceAttributes);
+     }
+ 
+     @Override
+     public Map<String, String> headers() {
+         return get(OtlpProperties::getHeaders, OtlpConfig.super::headers);
+     }
+ 
+ }

--- a/service-discovery/service/src/main/java/com/helloworld/service/ServiceApplication.java
+++ b/service-discovery/service/src/main/java/com/helloworld/service/ServiceApplication.java
@@ -1,9 +1,11 @@
 package com.helloworld.service;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@ImportAutoConfiguration(OtlpMetricsExportAutoConfiguration.class)
 public class ServiceApplication {
 
 	public static void main(final String[] args) {

--- a/service-discovery/service/src/main/resources/META-INF/spring.factories
+++ b/service-discovery/service/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.helloworld.service.OtlpMetricsExportAutoConfiguration

--- a/service-discovery/service/src/main/resources/META-INF/spring.factories
+++ b/service-discovery/service/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.helloworld.service.OtlpMetricsExportAutoConfiguration

--- a/service-discovery/service/src/main/resources/application.yml
+++ b/service-discovery/service/src/main/resources/application.yml
@@ -14,6 +14,16 @@ spring:
         prefer-ip-address: false
         tags: prometheus
 management:
+
+  otlp:
+    metrics:
+      export:
+        enabled: true
+        url: https://prometheus-prod-24-prod-eu-west-2.grafana.net/otlp/v1/metrics
+        step: 10s
+        headers:
+          Authorization: Basic #######
+
   metrics:
     distribution:
       slo:

--- a/service-discovery/service/src/main/resources/application.yml
+++ b/service-discovery/service/src/main/resources/application.yml
@@ -19,10 +19,11 @@ management:
     metrics:
       export:
         enabled: true
-        url: https://prometheus-prod-24-prod-eu-west-2.grafana.net/otlp/v1/metrics
         step: 10s
-        headers:
-          Authorization: Basic #######
+        url: http://mimir:9009/otlp/v1/metrics
+        # url: https://prometheus-prod-24-prod-eu-west-2.grafana.net/otlp/v1/metrics
+        # headers:
+        #   Authorization: Basic ####
 
   metrics:
     distribution:

--- a/service-discovery/service/src/main/resources/logback.xml
+++ b/service-discovery/service/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
         </http>
         <format>
             <label>
-                <pattern>application=${app},host=${HOSTNAME},level=%level</pattern>
+                <pattern>application=${app},host=${HOSTNAME},level=%level,env=${SERVICE_ENV}</pattern>
             </label>
             <message>
                 <pattern>l=%level h=${HOSTNAME} c=%logger{20} t=%thread traceId=%X{trace_id} spanId=%X{span_id} | %msg %ex</pattern>

--- a/service-discovery/service/supervisor.d/app.ini
+++ b/service-discovery/service/supervisor.d/app.ini
@@ -5,7 +5,7 @@ command=java
     -Dotel.service.name=%(ENV_SERVICE_NAME)s
     -Dotel.traces.sampler=parentbased_traceidratio
     -Dotel.traces.sampler.arg=0.1
-    -jar /app/main.jar --spring.application.name=%(ENV_SERVICE_NAME)s --management.otlp.metrics.export.resourceAttributes.service.name=%(ENV_SERVICE_NAME)s --management.otlp.metrics.export.resourceAttributes.service.instance.id=%(host_node_name)s --management.metrics.tags.env=%(ENV_SERVICE_ENV)s
+    -jar /app/main.jar --spring.application.name=%(ENV_SERVICE_NAME)s --management.otlp.metrics.export.resourceAttributes.service.name=%(ENV_SERVICE_NAME)s --management.otlp.metrics.export.resourceAttributes.service.instance.id=%(host_node_name)s --management.metrics.tags.env=%(ENV_SERVICE_ENV)s --management.metrics.tags.application=%(ENV_SERVICE_NAME)s
 autorestart=false
 startretries=0
 stdout_logfile=/dev/fd/1

--- a/service-discovery/service/supervisor.d/app.ini
+++ b/service-discovery/service/supervisor.d/app.ini
@@ -5,7 +5,7 @@ command=java
     -Dotel.service.name=%(ENV_SERVICE_NAME)s
     -Dotel.traces.sampler=parentbased_traceidratio
     -Dotel.traces.sampler.arg=0.1
-    -jar /app/main.jar --spring.application.name=%(ENV_SERVICE_NAME)s --management.otlp.metrics.export.resourceAttributes.service.name=%(ENV_SERVICE_NAME)s --management.otlp.metrics.export.resourceAttributes.service.instance.id=%(host_node_name)s
+    -jar /app/main.jar --spring.application.name=%(ENV_SERVICE_NAME)s --management.otlp.metrics.export.resourceAttributes.service.name=%(ENV_SERVICE_NAME)s --management.otlp.metrics.export.resourceAttributes.service.instance.id=%(host_node_name)s --management.metrics.tags.env=%(ENV_SERVICE_ENV)s
 autorestart=false
 startretries=0
 stdout_logfile=/dev/fd/1

--- a/service-discovery/service/supervisor.d/app.ini
+++ b/service-discovery/service/supervisor.d/app.ini
@@ -5,7 +5,7 @@ command=java
     -Dotel.service.name=%(ENV_SERVICE_NAME)s
     -Dotel.traces.sampler=parentbased_traceidratio
     -Dotel.traces.sampler.arg=0.1
-    -jar /app/main.jar --spring.application.name=%(ENV_SERVICE_NAME)s
+    -jar /app/main.jar --spring.application.name=%(ENV_SERVICE_NAME)s --management.otlp.metrics.export.resourceAttributes.service.name=%(ENV_SERVICE_NAME)s --management.otlp.metrics.export.resourceAttributes.service.instance.id=%(host_node_name)s
 autorestart=false
 startretries=0
 stdout_logfile=/dev/fd/1

--- a/service-discovery/tempo/tempo-local.yaml
+++ b/service-discovery/tempo/tempo-local.yaml
@@ -1,28 +1,28 @@
-# https://github.com/grafana/tempo/blob/main/example/docker-compose/local/tempo-local.yaml
-# metrics_generator_enabled: true
-
-search_enabled: true
-
+# https://github.com/grafana/tempo/blob/main/example/docker-compose/shared/tempo.yaml
 server:
   http_listen_port: 3200
 
 distributor:
   receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
+    # jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can
+    #   protocols:                       # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
+    #     thrift_http:                   #
+    #     grpc:                          # for a production deployment you should only enable the receivers you need!
+    #     thrift_binary:
+    #     thrift_compact:
+    # zipkin:
     otlp:
       protocols:
+        # http:
         grpc:
+    opencensus:
 
 ingester:
-  trace_idle_period: 10s               # the length of time after a trace has not received spans to consider it complete and flush it
-  max_block_bytes: 1_000_000           # cut the head block when it hits this size or ...
-  max_block_duration: 5m               #   this much time passes
+  max_block_duration: 5m               # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally
 
 compactor:
   compaction:
-    compaction_window: 1h              # blocks in this time window will be compacted together
-    max_block_bytes: 100_000_000       # maximum size of compacted blocks
-    block_retention: 1h
-    compacted_block_retention: 10m
+    block_retention: 1h                # overall Tempo trace retention. set for demo purposes
 
 # metrics_generator:
 #   registry:
@@ -38,18 +38,10 @@ compactor:
 storage:
   trace:
     backend: local                     # backend configuration to use
-    block:
-      bloom_filter_false_positive: .05 # bloom filter false positive rate.  lower values create larger filters but fewer false positives
-      index_downsample_bytes: 1000     # number of bytes per index record
-      encoding: zstd                   # block encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
     wal:
       path: /tmp/tempo/wal             # where to store the the wal locally
-      encoding: snappy                 # wal encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
     local:
       path: /tmp/tempo/blocks
-    pool:
-      max_workers: 100                 # worker pool determines the number of parallel requests to the object store backend
-      queue_depth: 10000
 
 # overrides:
-#   metrics_generator_processors: [service-graphs, span-metrics]
+#   metrics_generator_processors: [service-graphs, span-metrics] # enables metrics generator


### PR DESCRIPTION
2 examples of metrics collector : push and pull to see pros and cons. With pull, service discovery and much more porcelain and plumbing should be in place

- [x] add otlp metrics to client and service
- [x] import v3 otlp autoconfigure class as a temporary workaround 
- [x] add a readme section for http/https proxy support on appender and micrometer registries
- [x] setup and test with grafana cloud
- [x] setup mimir
- [x] configure mimir dashboard (due to metrics naming conflict between prometheus and otlp micrometer registries, dashboards has been cloned by datasource. A hidden datasource variable has been added though)
- [x] otlp buckets from micrometer-registry-otlp are really different but seems better than prometheus one (percentile + timings vs timings + counter)
- [x] update docker images version
- [x] update loki dep version 
- [x] setup loki conf
- [x] upgrade tempo to v2 and update conf 